### PR TITLE
Rubocop: set target ruby version to 2.5.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 # Ref: https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 AllCops:
+  TargetRubyVersion: 2.5.0
   Rails:
     Enabled: true
   Exclude:


### PR DESCRIPTION
たとえば `&.foo` と、Safe Navigation Operator を使ったときに「対象としている Ruby のバージョンと違う」みたいに表示されるので、実態の方に合わせる

![a41510d5d20232333666555e1952b87b](https://user-images.githubusercontent.com/1916541/37276901-8023a81e-2626-11e8-93fe-96010a7655aa.png)
