### PR TITLE
Add inch-ci badge to visualize inline doc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Inline docs](http://inch-ci.org/github/gouf/url_mind.svg?branch=develop)](http://inch-ci.org/github/gouf/url_mind)
 
 # Tools
 


### PR DESCRIPTION
Inch CI でインラインドキュメントを可視化します

# Link

* [Inch CI - Documentation badges for Ruby, JS & Elixir projects - Show off your docs](https://inch-ci.org/)