### PR TITLE
Specify bundler version as 1.16.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'jquery-rails'
 gem 'nokogiri'
 gem 'redcarpet'
 gem 'unshorten'
+gem 'bundler', '1.16.1'
 
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,6 +403,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap (~> 4.0.0)
   bullet
+  bundler (= 1.16.1)
   byebug
   capybara (~> 2.13)
   coveralls
@@ -448,3 +449,6 @@ DEPENDENCIES
   unshorten
   web-console (>= 3.3.0)
   yard
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
bundler のバージョン違いで Push failed になる...???

```
-----> Ruby app detected
-----> Compiling Ruby/Rails
-----> Using Ruby version: ruby-2.3.4
-----> Installing dependencies using bundler 1.15.2
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
       Warning: the running version of Bundler (1.15.2) is older than the version that created the lockfile (1.16.1). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
```