### PR TITLE
[WIP] Refactor: split into JobGrouping class

### DIFF
--- a/lib/job_grouping.rb
+++ b/lib/job_grouping.rb
@@ -1,0 +1,33 @@
+# Separate jobs into groups for delay processing of Active Job
+class JobGrouping
+  def initialize(ids, group_delay_seconds: 30, process_group_chunk: 30)
+    @delay_seconds = group_delay_seconds
+    @process_group_chunk = process_group_chunk
+    @ids = ids
+  end
+
+  # compose delay seconds group and processing ids group
+  def separate_to_groups
+    delay_group.zip(process_group)
+    # => [
+    #   [30, [1, 2, 3, ...]],
+    #   [60, [10, 11, 12, ...]],
+    #   ...,
+    # ]
+  end
+
+  private
+
+  # split record ids into group by chunk size
+  def process_group
+    slice_size = 0.step(@ids.size, @process_group_chunk).size
+
+    @ids.each_slice(slice_size).lazy
+    # => [[1, 2, 3, ...], [10, 11, 12, ...], ...]
+  end
+
+  def delay_group
+    Array.new(process_group.size, nil).inject([]) { |ret, _| ret << ret.last.to_i + @delay_seconds }.lazy
+    # => [30, 60, 90, 120, ...]
+  end
+end

--- a/lib/job_grouping.rb
+++ b/lib/job_grouping.rb
@@ -20,7 +20,7 @@ class JobGrouping
 
   # split record ids into group by chunk size
   def process_group
-    slice_size = 0.step(@ids.size, @process_group_chunk).size
+    slice_size = 0.step(@ids.size - 1, @process_group_chunk).size
 
     @ids.each_slice(slice_size).lazy
     # => [[1, 2, 3, ...], [10, 11, 12, ...], ...]

--- a/spec/unit/job_grouping_spec.rb
+++ b/spec/unit/job_grouping_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'job_grouping' # lib/job_grouping.rb
+
+describe JobGrouping do
+  context 'when 100 ids passed' do
+    let(:ids) { (1..10).to_a }
+
+    subject { JobGrouping.new(ids, group_delay_seconds: 1, process_group_chunk: 5).separate_to_groups.to_a }
+
+    it 'class is Enumerator::Lazy' do
+      klass =
+        JobGrouping.new(ids, group_delay_seconds: 1, process_group_chunk: 5)
+        .separate_to_groups
+        .class
+
+      expect(klass).to eq Enumerator::Lazy
+    end
+
+    it 'returns 5 groups of array' do
+      pp subject
+      s = subject.dup
+      s.map! { |x| [x.first, x.last.size] }
+      pp s
+      expect(subject.size).to eq 5
+    end
+
+    it 'ids separated as [1, 2], [3, 4], [5, 6], [7, 8], [9, 10]' do
+      grouped_ids = subject.map(&:last)
+
+      expect(grouped_ids).to eq [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
+    end
+
+    it 'last of delay group is 5 sec.' do
+      last_delay_group_sec = subject.last.first
+
+      expect(last_delay_group_sec).to eq 5
+    end
+  end
+end

--- a/spec/unit/job_grouping_spec.rb
+++ b/spec/unit/job_grouping_spec.rb
@@ -18,10 +18,6 @@ describe JobGrouping do
     end
 
     it 'returns 5 groups of array' do
-      pp subject
-      s = subject.dup
-      s.map! { |x| [x.first, x.last.size] }
-      pp s
       expect(subject.size).to eq 5
     end
 


### PR DESCRIPTION
`app/jobs/dispatch_404_url_deletion_job.rb` が実際なにやってるのか よくわからない

ので、ジョブの実行に直接関わらない部分を `JobGrouping` (`lib/job_grouping.rb`) クラスを新設してお引っ越しする