### PR TITLE
Card type url lists

### DIFF
--- a/app/assets/stylesheets/read_laters.scss
+++ b/app/assets/stylesheets/read_laters.scss
@@ -1,3 +1,39 @@
 // Place all the styles related to the ReadLaters controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.read_later {
+  &-items {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  &-item {
+    align-self: center;
+    background: #DEDEDE;
+    width: 30%;
+    margin: 0.3rem;
+    margin-top: 0.8rem;
+    padding: 1.5rem;
+    cursor: pointer;
+
+    &:hover {
+      background: #CECECE;
+    }
+
+    & li {
+      padding-left: 1rem;
+      list-style: none;
+    }
+
+    &_title {
+      padding: 1rem;
+      font-size: 1.8rem;
+    }
+
+    &_url {
+      font-size: 0.8rem;
+      overflow: hidden;
+    }
+  }
+}

--- a/app/models/read_later.rb
+++ b/app/models/read_later.rb
@@ -19,11 +19,15 @@ class ReadLater < ApplicationRecord
   # Save to records for multiple Markdown list style URLs
   # @param markdown_list_style_urls [String] the Markdown list style URLs
   def self.bulk_push(markdown_list_style_urls)
+    titles = extract_titles_from_markdown(markdown_list_style_urls)
     urls = extract_urls_from_markdown(markdown_list_style_urls)
 
     ReadLater.transaction do
-      urls.each do |url|
-        ReadLater.create!(url: url)
+      [titles, urls].transpose.each do |title, url|
+        ReadLater.create!(
+          title: title,
+          url: url
+        )
       end
     end
   end
@@ -38,5 +42,11 @@ class ReadLater < ApplicationRecord
     html = Markdown.new(markdown_list_style_urls).to_html
     links = Nokogiri::HTML(html)
     links.css('a').map { |element| element.attribute('href').value }
+  end
+
+  def self.extract_titles_from_markdown(markdown_list_style_urls)
+    html = Markdown.new(markdown_list_style_urls).to_html
+    links = Nokogiri::HTML(html)
+    links.css('a').map(&:text)
   end
 end

--- a/app/views/read_laters/index.html.slim
+++ b/app/views/read_laters/index.html.slim
@@ -9,11 +9,13 @@
   = form_tag(read_laters_bulk_push_path)
     .form-group
       label[for="urls"] Paste Markdown List style URLs:
-      textarea#urls.form-control[rows="30" cols="80" name="read_laters[url]"]
+      textarea#urls.form-control[rows="13" cols="10" name="read_laters[url]"]
     .form-group
       = submit_tag('submit', class: 'btn btn-secondary btn-block')
 
-.container.mb-3
-  - @read_laters.first(10).each do |read_later|
-    ul.list-group
-      li.list-group-item = read_later.url
+.container
+  .read_later-items.md-3
+    - @read_laters.first(10).each do |read_later|
+      ul.list-group.read_later-item
+        li.read_later-item_title = read_later.title
+        li.read_later-item_url = read_later.url

--- a/db/migrate/20181107070005_add_title_column_to_readlater.rb
+++ b/db/migrate/20181107070005_add_title_column_to_readlater.rb
@@ -1,0 +1,9 @@
+class AddTitleColumnToReadlater < ActiveRecord::Migration[5.1]
+  def up
+    add_column :read_laters, :title, :string, null: false, default: ''
+  end
+
+  def down
+    remove_column :read_laters, :title, :string, null: false, default: ''
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,14 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+if Rails.env.development?
+  ReadLater.destroy_all
+  50.times do |i|
+    url = 'https://www.example.com/'
+    ReadLater.create!(
+      title: "some of title #{i}",
+      url: "#{url}#{i}"
+    )
+  end
+end

--- a/spec/models/read_later_spec.rb
+++ b/spec/models/read_later_spec.rb
@@ -3,10 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe ReadLater, type: :model do
+  let(:markdown_text) do
+    _ = <<-MARKDOWN.strip
+      [title A](http://example.com)
+      [title B](http://example.com)
+    MARKDOWN
+  end
+
   context 'saving record' do
+    let(:record) do
+      ReadLater.create!(
+        title: 'test record title',
+        url: 'http%3A%2F%2Fexample.com'
+      )
+    end
+
     it 'has decoded url' do
-      ReadLater.create(url: 'http%3A%2F%2Fexample.com')
-      expect(ReadLater.first.url).to eq 'http://example.com'
+      expect(record.url).to eq 'http://example.com'
+    end
+
+    it 'has title' do
+      ReadLater.bulk_push(markdown_text)
+      expect(ReadLater.first.title).to eq 'title A'
     end
 
     after(:each) { ReadLater.destroy_all }
@@ -16,5 +34,17 @@ RSpec.describe ReadLater, type: :model do
     subject { ReadLater.pop! }
 
     it { is_expected.to be_nil }
+  end
+
+  context 'and markdown text data' do
+    it 'can get urls' do
+      urls = ReadLater.extract_urls_from_markdown(markdown_text)
+      expect(urls).to match (['http://example.com'] * 2)
+    end
+
+    it 'can get title' do
+      titles = ReadLater.extract_titles_from_markdown(markdown_text)
+      expect(titles).to match %w[title\ A title\ B]
+    end
   end
 end


### PR DESCRIPTION
# 概要

ReadLater モデルに保存する項目に「タイトル」を追加する

これで:

* [x] Markdown フォーマットでの URL リスト形式のデータから、タイトル情報を保存できる
* [x] URL 情報以外にタイトル文字列によって アクセス先 Web ページを判別できる

![カード型 URL 表示](https://i.gyazo.com/b6f9d9b5742a30f4624e427078fd4410.png)

# 実装しないこと

* カードをクリックすることで そのクリックしたページを別タブで表示させる

(今回の Pull Request では実装しない)